### PR TITLE
Don't set DOCKER_HOST if it is not needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ DockerStream.prototype.runDocker = function(imageName, options) {
   var self = this
   self.getDockerVersion(function(err, version) {
     if (err) return self.stream.destroy(err)
-    var env = xtend({"DOCKER_HOST": options.host}, process.env)
+    var env = options.host ? xtend({"DOCKER_HOST": options.host}, process.env) : process.env
     var runArgs = ['run', '-i', '--rm', imageName]
     debug('running docker w/ args', runArgs, {env: env})
     var run = spawn('docker', ['run', '-i', '--rm', imageName], {env: env})


### PR DESCRIPTION
When using this on platforms that have native docker support, I get an error that looks like:

```
FATA[0000] Invalid bind address format: undefined  
```

which is caused by setting the DOCKER_HOST environment variable to "undefined".  This pull request prevents it form setting that environment variable unless it's required.
